### PR TITLE
Fix procedure-arity for '+' and '*'

### DIFF
--- a/racketscript-compiler/racketscript/compiler/assembler.rkt
+++ b/racketscript-compiler/racketscript/compiler/assembler.rkt
@@ -74,6 +74,7 @@
      (emit-args args ",")
      (emit ")")]
     [(ILBinaryOp oper args)
+     (assert (>= (length args) 2)) ;; TODO: Update the type of ILBinaryOp
      (for/last? ([arg last? args])
        (when (ILBinaryOp? arg) (emit "("))
        (assemble-expr arg out)

--- a/racketscript-compiler/racketscript/compiler/runtime/kernel.rkt
+++ b/racketscript-compiler/racketscript/compiler/runtime/kernel.rkt
@@ -90,9 +90,9 @@
 
 (define+provide (single-flonum-available?) #f)
 
-(define+provide *  (#js.Core.attachProcedureArity #js.Core.Number.mul 1))
+(define+provide *  (#js.Core.attachProcedureArity #js.Core.Number.mul 0))
 (define+provide /  (#js.Core.attachProcedureArity #js.Core.Number.div 1))
-(define+provide +  (#js.Core.attachProcedureArity #js.Core.Number.add 1))
+(define+provide +  (#js.Core.attachProcedureArity #js.Core.Number.add 0))
 (define+provide -  (#js.Core.attachProcedureArity #js.Core.Number.sub 1))
 (define+provide <  (#js.Core.attachProcedureArity #js.Core.Number.lt 1))
 (define+provide >  (#js.Core.attachProcedureArity #js.Core.Number.gt 1))

--- a/racketscript-compiler/racketscript/compiler/transform.rkt
+++ b/racketscript-compiler/racketscript/compiler/transform.rkt
@@ -434,7 +434,7 @@
          [(and (equal? v (ImportedIdent '/ '#%kernel #t))
                (length=? arg* 1))
           (ILBinaryOp '/ (cons (ILValue 1) arg*))]
-         [(and (ImportedIdent? v) (member v binops))
+         [(and (ImportedIdent? v) (member v binops) (> (length arg* ) 0))
           (ILBinaryOp (ImportedIdent-id v) arg*)]
          [else (ILApp v-il arg*)]))
 
@@ -1007,6 +1007,12 @@
   ;; --------------------------------------------------------------------------
 
   (test-case "Identify binary operators"
+    (check-ilexpr (PlainApp (kident '+) '())
+                  '()
+                  (ILApp (ILRef 'kernel '+) '()))
+    (check-ilexpr (PlainApp (kident '/) '())
+                  '()
+                  (ILApp (ILRef 'kernel '/) '()))
     (check-ilexpr (PlainApp (kident '+) (list (Quote 1) (Quote 2)))
                   '()
                   (ILBinaryOp '+ (list (ILValue 1) (ILValue 2))))

--- a/tests/basic/arithmatic.rkt
+++ b/tests/basic/arithmatic.rkt
@@ -51,3 +51,6 @@
 (displayln (<= 1 2 3))
 (displayln (> 1 2 3))
 (displayln (>= 1 2 3))
+
+(displayln (+))
+(displayln (*))

--- a/tests/basic/procedure-arity.rkt
+++ b/tests/basic/procedure-arity.rkt
@@ -18,3 +18,9 @@
 (displayln (equal? (procedure-arity foo) (arity-at-least 2)))
 (displayln (equal? (procedure-arity bar) (arity-at-least 0)))
 (displayln (equal? (procedure-arity baz) 3))
+
+(displayln (equal? (procedure-arity +) (arity-at-least 0)))
+(displayln (equal? (procedure-arity -) (arity-at-least 1)))
+(displayln (equal? (procedure-arity *) (arity-at-least 0)))
+(displayln (equal? (procedure-arity /) (arity-at-least 1)))
+


### PR DESCRIPTION
The issue discussed over https://github.com/vishesh/racketscript/pull/156#discussion_r332808543 was a bug in compiler which expanded arithmetic ops to JavaScript operators. It broke when 0 args were provided, as the assembler didn't check if correct the input was correct (or we should fix the type the `ILBinaryOp` to take two arguments.